### PR TITLE
CR feedback for JS map stuff

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -15,6 +15,9 @@ typedef ReactComponentFactoryProxy ComponentRegistrar(
 
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/react-component.html)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/react-component.html#reference)
+///
+/// __Deprecated. Use [Component2] instead.__
+@Deprecated('6.0.0')
 abstract class Component {
   Map _context;
 
@@ -516,66 +519,115 @@ abstract class Component2<T extends Map> implements Component {
 
   // Unsupported things
 
-  // Unsupported things
-
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   void replaceState(Map newState, [SetStateCallback callback]) =>
       throw new UnimplementedError();
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Map<String, dynamic> getChildContext() => const {};
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   void componentWillUpdateWithContext(
       Map nextProps, Map nextState, Map nextContext) {}
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   void componentWillReceivePropsWithContext(Map newProps, nextContext) {}
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   bool shouldComponentUpdateWithContext(
           Map nextProps, Map nextState, Map nextContext) =>
       null;
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Iterable<String> get childContextKeys => const [];
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Iterable<String> get contextKeys => const [];
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   bind(key) => [
         state[key],
         (value) => setState({key: value})
       ];
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   initComponentInternal(props, _jsRedraw, [Ref ref, _jsThis, context]) {
     throw new UnimplementedError();
   }
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   initStateInternal() => throw new UnimplementedError();
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Map nextContext; // todo make throwing getters/setters
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Map prevContext; // todo make throwing getters/setters
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Map prevState; // todo make throwing getters/setters
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Map get nextState => throw new UnimplementedError();
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   Map nextProps; // todo make throwing getters/setters
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   void transferComponentState() => throw new UnimplementedError();
 
-  @Deprecated('3.0.0')
+  /// Do not use.
+  ///
+  /// Will be removed when [Component] is removed in the `6.0.0` release.
+  @Deprecated('6.0.0')
   void redraw([SetStateCallback callback]) {
     setState({}, callback);
   }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -147,8 +147,8 @@ class ReactDartComponentFactoryProxy<TComponent extends Component>
   }
 }
 
-/// Creates ReactJS [Component] instances for Dart components.
-class ReactDartComponentFactoryProxy2<TComponent extends Component>
+/// Creates ReactJS [Component2] instances for Dart components.
+class ReactDartComponentFactoryProxy2<TComponent extends Component2>
     extends ReactComponentFactoryProxy
     implements ReactDartComponentFactoryProxy {
   /// The ReactJS class used as the type for all [ReactElement]s built by

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -67,7 +67,10 @@ dynamic listifyChildren(dynamic children) {
   }
 }
 
-/// Creates ReactJS [Component] instances for Dart components.
+/// Use [ReactDartComponentFactoryProxy2] instead.
+///
+/// Will be removed when [Component] is removed in the `6.0.0` release.
+@Deprecated('6.0.0')
 class ReactDartComponentFactoryProxy<TComponent extends Component>
     extends ReactComponentFactoryProxy {
   /// The ReactJS class used as the type for all [ReactElement]s built by
@@ -182,7 +185,7 @@ class ReactDartComponentFactoryProxy2<TComponent extends Component2>
 
     if (children == null) {
       // FIXME are we cool to modify this list?
-      // FIXME why are there unmofiable lists here?
+      // FIXME why are there unmodifiable lists here?
       children = childrenArgs.map(listifyChildren).toList();
       markChildrenValidated(children);
     }
@@ -253,6 +256,7 @@ Map<String, dynamic> _unjsifyContext(InteropContextValue interopContext) {
 }
 
 /// The static methods that proxy JS component lifecycle methods to Dart components.
+// TODO: Remove in the 6.0.0 release
 final ReactDartInteropStatics _dartInteropStatics = (() {
   var zone = Zone.current;
 
@@ -605,6 +609,7 @@ final ReactDartInteropStatics2 _dartInteropStatics2 = (() {
 
 /// Creates and returns a new [ReactDartComponentFactoryProxy] from the provided [componentFactory]
 /// which produces a new JS [`ReactClass` component class](https://facebook.github.io/react/docs/top-level-api.html#react.createclass).
+// TODO: Remove in the 6.0.0 release
 ReactDartComponentFactoryProxy _registerComponent(
     ComponentFactory componentFactory,
     [Iterable<String> skipMethods = const []]) {
@@ -675,6 +680,7 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
   ReactDomComponentFactoryProxy(name)
       : this.name = name,
         this.factory = React.createFactory(name) {
+    // TODO: Should we remove this once we validate that the bug is gone in Dart 2 DDC?
     if (ddc_emulated_function_name_bug.isBugPresent) {
       ddc_emulated_function_name_bug.patchName(this);
     }

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -72,8 +72,9 @@ class ReactClass {
   ///
   /// For use in [ReactDartComponentFactoryProxy] when creating new [ReactElement]s,
   /// or for external use involving inspection of Dart prop defaults.
-  @Deprecated('2.0.0')
+  @Deprecated('6.0.0')
   external Map get dartDefaultProps;
+  @Deprecated('6.0.0')
   external set dartDefaultProps(Map value);
 
   external String get dartComponentVersion;
@@ -321,8 +322,14 @@ external bool get _inReactDevMode;
 bool get inReactDevMode => _inReactDevMode;
 
 /// An object that stores static methods used by all Dart components.
+///
+/// __Deprecated.__ Use [ReactDartInteropStatics2] instead.
+///
+/// Will be removed when [Component] is removed in the `6.0.0` release.
 @JS()
 @anonymous
+
+@Deprecated('6.0.0')
 class ReactDartInteropStatics {
   external factory ReactDartInteropStatics({
     _InitComponent initComponent,
@@ -362,6 +369,7 @@ class ReactDartInteropStatics2 implements ReactDartInteropStatics {
 /// passes it to certain methods in [ReactDartInteropStatics].
 ///
 /// See [ReactDartInteropStatics], [createReactDartComponentClass].
+// TODO: Do we need a version 2 of this?
 class ComponentStatics<T extends Component> {
   final ComponentFactory<T> componentFactory;
 


### PR DESCRIPTION
Updated deprecation annotations / comments / changed one instance of `Component` to `Component2` while reviewing https://github.com/cleandart/react-dart/pull/161

@greglittlefield-wf 